### PR TITLE
Jitsi JWT Authentication

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -24,6 +24,10 @@ HU_GRAPHQL_PLAYGROUND_ACTIVE=<true/false>
 
 # == JITSI ==
 HU_JITSI_HOST=<jitsi_host>
+# If JWT can be used for authentication of participants. (Custom Jitsi-Installation required, defaults to false)
+HU_JITSI_JWT_ENABLED=<true/false>
+HU_JITSI_JWT_APP_ID=<app_id>
+HU_JITSI_JWT_SECRET=<secret>
 
 # == MEETINGS ==
 # The number of minutes before a meeting starts, that the host is allowed to create the conference

--- a/apps/api/src/config/jitsi/config.module.ts
+++ b/apps/api/src/config/jitsi/config.module.ts
@@ -10,6 +10,15 @@ import configuration from './configuration';
       load: [configuration],
       validationSchema: Joi.object({
         HU_JITSI_HOST: Joi.string().required(),
+        HU_JITSI_JWT_ENABLED: Joi.boolean(),
+        HU_JITSI_JWT_APP_ID: Joi.when('HU_JITSI_JWT_ENABLED', {
+          is: true,
+          then: Joi.string().required(),
+        }),
+        HU_JITSI_JWT_SECRET: Joi.when('HU_JITSI_JWT_ENABLED', {
+          is: true,
+          then: Joi.string().required(),
+        }),
       }),
       validationOptions: {
         allowUnknown: true,

--- a/apps/api/src/config/jitsi/config.service.ts
+++ b/apps/api/src/config/jitsi/config.service.ts
@@ -1,11 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
+interface JitsiJwtConfig {
+  enabled: boolean;
+  appId: string;
+  secret: string;
+}
+
 @Injectable()
 export class JitsiConfigService {
   constructor(private configService: ConfigService) {}
 
   get host(): string {
     return this.configService.get<string>('jitsi.host');
+  }
+
+  get jwt(): JitsiJwtConfig {
+    return this.configService.get<JitsiJwtConfig>('jitsi.jwt');
   }
 }

--- a/apps/api/src/config/jitsi/configuration.ts
+++ b/apps/api/src/config/jitsi/configuration.ts
@@ -2,4 +2,9 @@ import { registerAs } from '@nestjs/config';
 
 export default registerAs('jitsi', () => ({
   host: process.env.HU_JITSI_HOST,
+  jwt: {
+    enabled: process.env.HU_JITSI_JWT_ENABLED || false,
+    appId: process.env.HU_JITSI_JWT_APP_ID || '',
+    secret: process.env.HU_JITSI_JWT_SECRET || '',
+  },
 }));


### PR DESCRIPTION
Funktionalität zur Verwendung von JWT zur Authentifizierung auf einer Jitsi-Instanz. Im Token wird gesetzt, ob der Benutzer ein Moderator ist, was die Verwendung des [Token Moderation](https://github.com/nvonahsen/jitsi-token-moderation-plugin/) Plugins ermöglicht.