### PR TITLE
Meeting pagination

### DIFF
--- a/apps/client/public/locales/de/translation.json
+++ b/apps/client/public/locales/de/translation.json
@@ -96,6 +96,10 @@
       "main": "Erstellen, kategorisieren, suchen und teilnehmen von virtuellen Treffen über interessierte Themen mit einander unbekannten Personen."
     }
   },
+  "pagination": {
+    "showMore": "Mehr anzeigen",
+    "showingCountOfTotal": "Zeigt {{count}} von {{total}} an"
+  },
   "meetings": {
     "head": {
       "title": {

--- a/apps/client/public/locales/en/translation.json
+++ b/apps/client/public/locales/en/translation.json
@@ -96,6 +96,10 @@
       "main": "Create, Categorize, Search and Join on virtual meetings about things you like with unfamiliar users."
     }
   },
+  "pagination": {
+    "showMore": "Show more",
+    "showingCountOfTotal": "Showing {{count}} of {{total}}"
+  },
   "meetings": {
     "head": {
       "title": {

--- a/apps/client/src/components/search-form/index.ts
+++ b/apps/client/src/components/search-form/index.ts
@@ -1,1 +1,2 @@
 export { default as SearchForm } from './search-form';
+export * from './search-form';

--- a/apps/client/src/components/search-form/search-form.tsx
+++ b/apps/client/src/components/search-form/search-form.tsx
@@ -7,10 +7,8 @@ import * as Yup from 'yup';
 import { Form, Formik } from 'formik';
 import { Button, Card, CardActions, CardContent, Grid } from '@material-ui/core';
 import { SearchField } from '../search-field';
-import { OrderField } from '../order-field';
 import { MeetingsVariables } from '../../models/meetings/__generated-interfaces__/Meetings';
 import { CardTitle } from '../card-title';
-import { OrderBy } from '../../models/__generated-interfaces__/globalTypes';
 import { DateTimeField } from '../datetime-field';
 import { TagsField } from '../tags';
 
@@ -29,36 +27,26 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
+export type SearchFormVariables = Pick<MeetingsVariables, 'searchValue' | 'fromDate' | 'toDate' | 'tags'>;
+
 interface SearchFormProps {
-  initialValues: MeetingsVariables;
-  onSubmit: (values: MeetingsVariables) => Promise<void>;
+  initialValues: SearchFormVariables;
+  onSubmit: (values: SearchFormVariables) => Promise<void>;
 }
 
-function SearchForm({
-  initialValues: { searchValue, startDateOrderBy, fromDate, toDate, tags, offset, limit },
-  onSubmit,
-}: SearchFormProps) {
+function SearchForm({ initialValues, onSubmit }: SearchFormProps) {
   const classes = useStyles();
   const { t } = useTranslation();
 
-  const orderOptions = [
-    { name: t('meetings.search.orderDesc'), value: OrderBy.DESC },
-    { name: t('meetings.search.orderAsc'), value: OrderBy.ASC },
-  ];
-
   const FormSchema = Yup.object().shape({
     value: Yup.string(),
-    order: Yup.string(),
     tags: Yup.array().of(Yup.object().shape({ id: Yup.number(), name: Yup.string() })),
     fromDate: Yup.string().nullable(),
     toDate: Yup.string().nullable(),
   });
 
   return (
-    <Formik
-      initialValues={{ searchValue, startDateOrderBy, tags, fromDate, toDate, offset, limit }}
-      validationSchema={FormSchema}
-      onSubmit={onSubmit}>
+    <Formik initialValues={initialValues} validationSchema={FormSchema} onSubmit={onSubmit}>
       {({ submitForm, isSubmitting, handleReset, setFieldValue }) => (
         <Form>
           <Card className={classes.card} variant="outlined">
@@ -71,9 +59,6 @@ function SearchForm({
                     placeholder={t('global.form.fields.search')}
                     setFieldValue={setFieldValue}
                   />
-                </Grid>
-                <Grid item xs={12}>
-                  <OrderField name="startDateOrderBy" label={t('global.form.fields.order')} options={orderOptions} />
                 </Grid>
                 <Grid item xs={12}>
                   <TagsField

--- a/apps/client/src/components/show-more/index.ts
+++ b/apps/client/src/components/show-more/index.ts
@@ -1,0 +1,1 @@
+export { default as ShowMore } from './show-more';

--- a/apps/client/src/components/show-more/show-more.tsx
+++ b/apps/client/src/components/show-more/show-more.tsx
@@ -1,0 +1,36 @@
+import { Box, Button, CircularProgress, Grid, Typography } from '@material-ui/core';
+import { KeyboardArrowDown } from '@material-ui/icons';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface ShowMoreProps {
+  currentCount: number;
+  totalCount: number;
+  onClick: () => void;
+  isLoading?: boolean;
+}
+
+function ShowMore({ currentCount, totalCount, onClick, isLoading }: ShowMoreProps) {
+  const { t } = useTranslation();
+  return (
+    <Box py={1}>
+      <Grid container direction="column" alignItems="center">
+        <Typography component="span" gutterBottom variant="body2">
+          {t('pagination.showingCountOfTotal', { count: currentCount, total: totalCount })}
+        </Typography>
+        <Button
+          variant="outlined"
+          onClick={onClick}
+          disabled={isLoading}
+          startIcon={isLoading ? <CircularProgress size="1em" /> : <KeyboardArrowDown />}>
+          {t('pagination.showMore')}
+        </Button>
+      </Grid>
+    </Box>
+  );
+}
+ShowMore.defaultProps = {
+  isLoading: false,
+};
+
+export default ShowMore;

--- a/apps/client/src/pages/meetings/meetings-page.tsx
+++ b/apps/client/src/pages/meetings/meetings-page.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@apollo/client';
+import { Collapse } from '@material-ui/core';
 import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
 import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 import FilterListIcon from '@material-ui/icons/FilterList';
@@ -10,49 +11,67 @@ import { MEETINGS } from '../../models/meetings';
 import { AppPageAside, AppPageMain } from '../../components/app-page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { isInFutureFilter, isWithinIntervalFilter } from '../../utils';
-import { SearchForm } from '../../components/search-form';
+import { SearchForm, SearchFormVariables } from '../../components/search-form';
 import { OrderBy } from '../../models/__generated-interfaces__/globalTypes';
-import { ShowMoreCard } from '../../components/show-more-card';
+import { ShowMore } from '../../components/show-more';
 
-function MeetingsPage() {
-  const { t } = useTranslation();
-
-  const initialValues: MeetingsVariables = {
-    searchValue: '',
-    startDateOrderBy: OrderBy.DESC,
-    tags: [],
-    fromDate: null,
-    toDate: null,
+function useMeetingsSearch(initialValues: SearchFormVariables, defaultOrderBy: OrderBy) {
+  const [currentSearch, setCurrentSearch] = useState(initialValues);
+  const baseOptions = {
+    startDateOrderBy: defaultOrderBy,
     offset: 0,
     limit: 5,
   };
 
-  const { loading, error, data, refetch } = useQuery<Meetings, MeetingsVariables>(MEETINGS, {
-    variables: initialValues,
+  const getQueryVariables = () => ({
+    ...currentSearch,
+    ...baseOptions,
   });
+
+  const { loading, error, data, refetch } = useQuery<Meetings, MeetingsVariables>(MEETINGS, {
+    variables: getQueryVariables(),
+  });
+
+  const search = (values: SearchFormVariables) => {
+    setCurrentSearch(values);
+    refetch(getQueryVariables());
+  };
+
+  const loadMore = () => {
+    refetch({ limit: data.discover.meetings.length + baseOptions.limit });
+  };
+
+  return { loading, error, data, search, loadMore };
+}
+
+function MeetingsPage() {
+  const { t } = useTranslation();
+
+  const initialValues = {
+    searchValue: '',
+    tags: [],
+    fromDate: null,
+    toDate: null,
+  };
+
+  const { loading, error, data, search, loadMore } = useMeetingsSearch(initialValues, OrderBy.ASC);
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error! ${error.message}</p>;
 
-  async function onSearch({ searchValue, startDateOrderBy, tags, fromDate, toDate, offset, limit }: MeetingsVariables) {
-    await refetch({
-      searchValue,
-      startDateOrderBy,
+  async function onSearch({ tags, ...values }: SearchFormVariables) {
+    search({
       tags: tags.map((tag) => {
         return { id: tag.id, name: tag.name };
       }),
-      fromDate,
-      toDate,
-      offset,
-      limit,
+      ...values,
     });
   }
   const { totalCount } = data.discover;
   // TODO: Filter out stopped meetings in query?
   const meetings = data.discover.meetings.filter((meeting) => !meeting.conference || !meeting.conference.stoppedAt);
-  const handlePageLimit = (max?: boolean) => {
-    const newLimit = max ? totalCount : initialValues.limit + meetings.length;
-    refetch({ limit: newLimit });
+  const handlePageLimit = () => {
+    loadMore();
   };
 
   return (
@@ -60,13 +79,6 @@ function MeetingsPage() {
       <AppPageAside>
         <SectionHeader icon={<FilterListIcon />} title={t('meetings.search.filterSection')} />
         <SearchForm onSubmit={onSearch} initialValues={initialValues} />
-        {totalCount > meetings.length && (
-          <ShowMoreCard
-            title={`${t('global.title.discover')} (${meetings.length}/${totalCount})`}
-            limit={initialValues.limit}
-            handlePageLimit={handlePageLimit}
-          />
-        )}
       </AppPageAside>
       <AppPageMain>
         <section>
@@ -77,6 +89,14 @@ function MeetingsPage() {
           <SectionHeader icon={<CalendarTodayIcon />} title={t('meetings.title.upcoming')} />
           <MeetingList meetings={isInFutureFilter(meetings)} />
         </section>
+        <Collapse in={totalCount > meetings.length}>
+          <ShowMore
+            totalCount={totalCount}
+            currentCount={meetings.length}
+            onClick={handlePageLimit}
+            isLoading={loading}
+          />
+        </Collapse>
       </AppPageMain>
     </>
   );


### PR DESCRIPTION
Pagination bei Meetings ist nun am Ende der Liste. Die Funktioanlität ist derzeit noch nicht auf der eigenen Meetings-Seite, da dort noch ein Mismatch zwischen vergangenen und zukünftigen Treffen besteht. Mit dem gleichen Filter vergangene und zukünftige Treffen zu filtern macht wenig Sinn und sollte besser separiert werden.