### PR TITLE
Fix meetings search

### DIFF
--- a/apps/client/src/components/meeting/meeting-detail-card.tsx
+++ b/apps/client/src/components/meeting/meeting-detail-card.tsx
@@ -145,9 +145,7 @@ function MeetingDetailCard({ meeting }: MeetingCardProps) {
             <Grid item>
               <Typography>{t('meetings.details.joinNow')}</Typography>
             </Grid>
-            <Grid item>
-              <ConferenceJoinButton conferenceId={meeting.conference?.id} />
-            </Grid>
+            <Grid item>{!!meeting.conference && <ConferenceJoinButton conferenceId={meeting.conference.id} />}</Grid>
           </Grid>
         </CardSection>
         <Divider />


### PR DESCRIPTION
- Loading-Anzeige ist nun innerhalb der Meetingliste, so wird die Suche nicht neu gerendert  und behält ihren State
- Es wird unterschieden ob refetched (gleiche Suche mit mehr Einträgen) oder neu gesucht wird